### PR TITLE
Requests fail over / timezone config / expire_at & delivry_at inside stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "proxyauth"
-version = "0.6.21"
+version = "0.7.0-beta0"
 dependencies = [
  "actix-governor",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "h2",
- "http 0.2.12",
+ "http",
  "httparse",
  "httpdate",
  "itoa",
@@ -89,7 +89,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http 0.2.12",
+ "http",
  "regex",
  "regex-lite",
  "serde",
@@ -978,7 +978,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.12",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -1007,7 +1007,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -1019,7 +1019,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.12",
+ "http",
 ]
 
 [[package]]
@@ -1055,24 +1055,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.12",
+ "http",
  "pin-project-lite",
 ]
 
@@ -1099,7 +1088,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -1121,7 +1110,7 @@ dependencies = [
  "bytes",
  "futures",
  "headers",
- "http 0.2.12",
+ "http",
  "hyper",
  "hyper-tls",
  "native-tls",
@@ -1137,7 +1126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.12",
+ "http",
  "hyper",
  "log",
  "rustls",
@@ -1827,7 +1816,7 @@ dependencies = [
 
 [[package]]
 name = "proxyauth"
-version = "0.7.0-beta0"
+version = "0.7.0"
 dependencies = [
  "actix-governor",
  "actix-http",
@@ -1844,7 +1833,6 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac",
- "http 1.3.1",
  "hyper",
  "hyper-proxy",
  "hyper-rustls",
@@ -1863,7 +1851,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
- "signal-hook",
  "socket2",
  "thiserror",
  "tokio",
@@ -2028,7 +2015,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.12",
+ "http",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -2293,16 +2280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,18 +2416,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ dependencies = [
  "foldhash",
  "futures-core",
  "h2",
- "http",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -89,7 +89,7 @@ checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -978,7 +978,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
  "indexmap",
  "slab",
  "tokio",
@@ -1007,7 +1007,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 0.2.12",
  "httpdate",
  "mime",
  "sha1",
@@ -1019,7 +1019,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.12",
 ]
 
 [[package]]
@@ -1055,13 +1055,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
@@ -1088,7 +1099,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "httparse",
  "httpdate",
@@ -1110,7 +1121,7 @@ dependencies = [
  "bytes",
  "futures",
  "headers",
- "http",
+ "http 0.2.12",
  "hyper",
  "hyper-tls",
  "native-tls",
@@ -1126,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.12",
  "hyper",
  "log",
  "rustls",
@@ -1833,6 +1844,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac",
+ "http 1.3.1",
  "hyper",
  "hyper-proxy",
  "hyper-rustls",
@@ -1853,6 +1865,7 @@ dependencies = [
  "sha2",
  "signal-hook",
  "socket2",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-loki",
@@ -2015,7 +2028,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.12",
  "http-body",
  "hyper",
  "hyper-tls",
@@ -2422,6 +2435,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.6.21"
+version = "0.7.0"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"
@@ -58,6 +58,8 @@ quanta = "0.12.5"
 hmac = "0.12"
 argon2 = "0.5"
 nix = "0.26"
+http = "1.0"
+thiserror = "1.0"
 clap = { version = "4", features = ["derive"] }
 signal-hook = "0.3"
 rand_chacha = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,8 @@ quanta = "0.12.5"
 hmac = "0.12"
 argon2 = "0.5"
 nix = "0.26"
-http = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 clap = { version = "4", features = ["derive"] }
-signal-hook = "0.3"
 rand_chacha = "0.3"
 dashmap = { version = "6.1.0", features = ["serde"] }
 once_cell = "1.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.7.0"
+version = "0.7.0.beta0"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.7.0.beta0"
+version = "0.7.0-beta0"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.7.0-beta0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -6,10 +6,12 @@ use crate::security::generate_token;
 use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use argon2::Argon2;
 use argon2::password_hash::{PasswordHash, PasswordVerifier};
-use chrono::{Duration, Utc};
-use chrono_tz::Europe::Paris;
+use chrono::{Duration, Utc, TimeZone};
+use chrono_tz::Tz;
 use rand::seq::SliceRandom;
 use rand::{Rng, thread_rng};
+use crate::AppConfig;
+use std::sync::Arc;
 use tracing::{info, warn};
 
 pub fn verify_password(input: &str, stored_hash: &str) -> bool {
@@ -33,6 +35,22 @@ pub fn generate_random_string(max_len: usize) -> String {
         .collect()
 }
 
+fn get_expiry_with_timezone(config: Arc<AppConfig>, optional_timestamp: Option<i64>) -> String {
+    let tz: Tz = config
+        .timezone
+        .parse()
+        .expect("Invalid timezone in config");
+
+    let utc_now = optional_timestamp
+        .map(|ts| Utc.timestamp_opt(ts, 0).single().expect("Invalid timestamp"))
+        .unwrap_or_else(Utc::now);
+
+    let local_time = utc_now.with_timezone(&tz);
+    let expiry = local_time + Duration::seconds(config.token_expiry_seconds);
+
+    expiry.timestamp().to_string()
+}
+
 pub async fn auth(
     req: HttpRequest,
     auth: web::Json<AuthRequest>,
@@ -52,16 +70,15 @@ pub async fn auth(
     {
         let user = &data.config.users[index_user];
 
-        let now = Utc::now();
-        let fr_time = now.with_timezone(&Paris);
-        let expiry = fr_time + Duration::seconds(data.config.token_expiry_seconds);
+
+        let expiry = get_expiry_with_timezone(data.config.clone(), None);
 
         let id_token = generate_random_string(48);
 
         let token = generate_token(
             &auth.username,
             &data.config,
-            &expiry.timestamp().to_string(),
+            &expiry,
             &id_token,
         );
 
@@ -70,13 +87,29 @@ pub async fn auth(
         let cipher_token = format!(
             "{}|{}|{}|{}",
             calcul_cipher(token.clone()),
-            expiry.timestamp(),
+            expiry,
             index_user,
             id_token
         );
 
         let token_encrypt = encrypt(&cipher_token, &key);
-        let expires_at_str = expiry.format("%Y-%m-%d %H:%M:%S").to_string();
+
+        let expiry_ts: i64 = expiry
+            .parse()
+            .expect("Invalid timestamp string");
+
+        let expiry_utc = Utc
+            .timestamp_opt(expiry_ts, 0)
+            .single()
+            .expect("Invalid timestamp value");
+
+        let tz: Tz = data.config
+            .timezone
+            .parse()
+            .expect("Invalid timezone");
+
+        let expiry_dt_local = expiry_utc.with_timezone(&tz);
+        let expires_at_str = expiry_dt_local.format("%Y-%m-%d %H:%M:%S").to_string();
 
         info!(
             "[{}] new token generated for user {} expirated at {}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,9 @@ pub struct RouteRule {
 
     #[serde(default = "default_cert")]
     pub cert: HashMap<String, String>,
+
+    #[serde(default = "default_backends")]
+    pub backends: Vec<String>,
 }
 
 #[derive(Default, Debug, Deserialize)]
@@ -136,6 +139,10 @@ fn default_port() -> u16 {
 }
 
 fn default_username() -> Vec<String> {
+    [].to_vec()
+}
+
+fn default_backends() -> Vec<String> {
     [].to_vec()
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,9 @@ pub struct AppConfig {
 
     #[serde(default = "default_max_idle_per_host")]
     pub max_idle_per_host: u16,
+
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
 }
 
 impl Serialize for AppConfig {
@@ -132,6 +135,10 @@ pub struct AuthRequest {
 
 fn default_host() -> String {
     "0.0.0.0".to_string()
+}
+
+fn default_timezone() -> String {
+    "Europe/Paris".to_string()
 }
 
 fn default_port() -> u16 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod security;
 pub mod timezone;
 pub mod tokencount;
 pub mod shared_client;
+pub mod loadbalancing;
 
 pub use auth::auth;
 pub use config::{AppConfig, AppState, RouteConfig};

--- a/src/loadbalancing.rs
+++ b/src/loadbalancing.rs
@@ -1,0 +1,60 @@
+use hyper::{Body, Client, Request, Response, Uri};
+use hyper_rustls::HttpsConnector;
+use hyper::body::to_bytes;
+use thiserror::Error;
+use hyper::Error as HyperError;
+
+#[derive(Debug, Error)]
+pub enum ForwardError {
+    #[error("All backends failed")]
+    AllBackendsFailed,
+
+    #[error(transparent)]
+    Hyper(#[from] HyperError),
+}
+
+pub async fn forward_failover(
+    req: Request<Body>,
+    backends: &[String],
+    client: &Client<HttpsConnector<hyper::client::HttpConnector>>,
+) -> Result<Response<Body>, ForwardError> {
+
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let headers = req.headers().clone();
+
+    let body_bytes = to_bytes(req.into_body()).await?;
+
+    for backend in backends {
+        let uri_backend: Uri = backend.parse().expect("Invalid backend URI");
+
+        let mut parts = uri.clone().into_parts();
+        parts.scheme = uri_backend.scheme().cloned();
+        parts.authority = uri_backend.authority().cloned();
+        parts.path_and_query = uri_backend.path_and_query().cloned();
+
+        let full_uri = Uri::from_parts(parts).expect("Invalid full URI");
+
+        let mut builder = Request::builder()
+            .method(method.clone())
+            .uri(full_uri);
+
+        for (key, value) in headers.iter() {
+            builder = builder.header(key, value);
+        }
+
+        let new_req = builder
+            .body(Body::from(body_bytes.clone()))
+            .expect("Error building request");
+
+        match client.request(new_req).await {
+            Ok(resp) => return Ok(resp),
+            Err(e) => {
+                tracing::warn!("Failover: backend {} failed: {}", backend, e);
+                continue;
+            }
+        }
+    }
+
+    Err(ForwardError::AllBackendsFailed)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod timezone;
 mod tokencount;
 mod tls;
 mod shared_client;
+mod loadbalancing;
 
 use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{App, HttpServer, web};

--- a/src/security.rs
+++ b/src/security.rs
@@ -158,7 +158,7 @@ pub async fn validate_token(
         .get(index_user)
         .ok_or("User not found")?;
 
-    let time_expire = check_date_token(data[1], &user.username, ip)
+    let time_expire = check_date_token(data[1], &user.username, ip, &config.timezone)
         .map_err(|_| "Your token is expired")?;
 
     if (time_expire > (config.token_expiry_seconds as i64).try_into().unwrap()).try_into().unwrap() {

--- a/src/security.rs
+++ b/src/security.rs
@@ -178,7 +178,7 @@ pub async fn validate_token(
     }
 
     if config.stats {
-        let count = data_app.counter.record_and_get(&user.username, data[3]);
+        let count = data_app.counter.record_and_get(&user.username, data[3], &time_expire.to_string());
 
         info!(
             "[{}] user {} is logged token expire in {} seconds [token used: {}]",

--- a/src/tokencount.rs
+++ b/src/tokencount.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicU64, Ordering};
-use chrono::Utc;
+use chrono::{Utc, Duration};
 use std::sync::Arc;
 use chrono::DateTime;
 use chrono::TimeZone;
@@ -61,8 +61,10 @@ impl CounterToken {
         let parsed_expire = expire_at.parse::<i64>()
             .expect("Invalid expire_at format");
 
+        let expire_timestamp = now + Duration::seconds(parsed_expire);
+
         let expire_at_datetime: DateTime<Utc> = Utc
-            .timestamp_opt(parsed_expire as i64, 0)
+            .timestamp_opt(expire_timestamp.timestamp(), 0)
             .single()
             .expect("timestamp is out of range");
 

--- a/src/tokencount.rs
+++ b/src/tokencount.rs
@@ -21,7 +21,7 @@ pub struct CounterToken {
 pub struct TokenUsage {
     pub token_id: String,
     pub count: AtomicU64,
-    pub delivry_at: DateTime<Utc>,
+    pub delivery_at: DateTime<Utc>,
     pub expire_at: DateTime<Utc>,
 }
 
@@ -71,7 +71,7 @@ impl CounterToken {
         let usage = self.counts.entry(key.clone()).or_insert_with(|| TokenUsage {
             token_id: token_id.to_string(),
             count: AtomicU64::new(0),
-            delivry_at: now,
+            delivery_at: now,
             expire_at: expire_at_datetime,
         });
 
@@ -104,7 +104,7 @@ impl CounterToken {
                     .push(TokenUsage {
                             token_id: token_id.to_string().clone(),
                             count: count.into(),
-                            delivry_at: usage.delivry_at,
+                            delivery_at: usage.delivery_at,
                             expire_at: usage.expire_at,
                     });
             }

--- a/src/tokencount.rs
+++ b/src/tokencount.rs
@@ -4,20 +4,25 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::sync::atomic::{AtomicU64, Ordering};
+use chrono::Utc;
 use std::sync::Arc;
+use chrono::DateTime;
+use chrono::TimeZone;
 
 type FxDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;
 
 #[derive(Debug)]
 pub struct CounterToken {
-    counts: FxDashMap<Arc<str>, AtomicU64>,
+    counts: FxDashMap<Arc<str>, TokenUsage>,
     key_cache: FxDashMap<(String, String), Arc<str>>, // Cache for reuse key
 }
 
-#[derive(Debug, Serialize, Clone)]
+#[derive(Debug, Serialize)]
 pub struct TokenUsage {
     pub token_id: String,
-    pub count: u64,
+    pub count: AtomicU64,
+    pub delivry_at: DateTime<Utc>,
+    pub expire_at: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,17 +47,41 @@ impl CounterToken {
             .clone()
     }
 
-    pub fn record_and_get(&self, user: &str, token_id: &str) -> u64 {
+//     pub fn record_and_get(&self, user: &str, token_id: &str) -> u64 {
+//         let key = self.make_key(user, token_id);
+//         let entry = self.counts.entry(key).or_insert_with(|| AtomicU64::new(0));
+//         entry.fetch_add(1, Ordering::Relaxed) + 1
+//     }
+
+    pub fn record_and_get(&self, user: &str, token_id: &str, expire_at: &str) -> u64 {
         let key = self.make_key(user, token_id);
-        let entry = self.counts.entry(key).or_insert_with(|| AtomicU64::new(0));
-        entry.fetch_add(1, Ordering::Relaxed) + 1
+        let now = Utc::now();
+
+        println!("{:?}", expire_at);
+        let parsed_expire = expire_at.parse::<i64>()
+            .expect("Invalid expire_at format");
+
+        let expire_at_datetime: DateTime<Utc> = Utc
+            .timestamp_opt(parsed_expire as i64, 0)
+            .single()
+            .expect("timestamp is out of range");
+
+        let usage = self.counts.entry(key.clone()).or_insert_with(|| TokenUsage {
+            token_id: token_id.to_string(),
+            count: AtomicU64::new(0),
+            delivry_at: now,
+            expire_at: expire_at_datetime,
+        });
+
+        usage.count.fetch_add(1, Ordering::Relaxed) + 1
     }
+
 
     pub fn get_count(&self, user: &str, token_id: &str) -> u64 {
         let key = self.make_key(user, token_id);
         self.counts
             .get(&key)
-            .map(|entry| entry.load(Ordering::Relaxed))
+            .map(|entry| entry.count.load(Ordering::Relaxed))
             .unwrap_or(0)
     }
 
@@ -65,13 +94,16 @@ impl CounterToken {
         for entry in self.counts.iter() {
             let key = entry.key();
             if let Some((user, token_id)) = key.split_once(':') {
-                let count = entry.value().load(Ordering::Relaxed);
+                let usage = entry.value(); // `&TokenUsage`
+                let count = entry.value().count.load(Ordering::Relaxed);
                 grouped
                     .entry(user.to_string())
                     .or_insert_with(|| Vec::with_capacity(4))
                     .push(TokenUsage {
-                        token_id: token_id.to_string(),
-                        count,
+                            token_id: token_id.to_string().clone(),
+                            count: count.into(),
+                            delivry_at: usage.delivry_at,
+                            expire_at: usage.expire_at,
                     });
             }
         }


### PR DESCRIPTION
<h2><b>Version</b>: >= 0.7.0</h2>
<h5><a target="_blank" href="https://crates.proxyauth.app/crate?name=proxyauth&version=0.7.0-beta0"><b>First beta version</b>: 0.7.0-beta0 </a></h5>

<details open>
<summary><h3>1- New function: Failover backends [TEST PASSED] ✅</h3></summary>

**Function**: Request fail over switch the backend.
**Comment**: if the first request is fail is use other url.

Configuration inside : <b>/etc/proxyauth/config/routes.yml</b>

     backends: ["http://your_uri/your_path_service", "http://second_uri/", "http://..."]


full exemple:
    
 ```   
routes:
  - prefix: "/app"
    target: "http://127.0.0.1:8500"
    secure: true
    username: ["admin"]
    backends: ["http://127.0.0.1:8501/", "http://127.0.0.1:8502"]
``` 
</details>

<details open>
<summary><h3>2 - New function: Timezone configuration [TEST PASSED] ✅</h3></summary>

Timezone configuration in <b>/etc/proxyauth/config/config.json</b>
**Token expiration now supports custom timezones**
<a href="https://docs.rs/chrono-tz/latest/chrono_tz/enum.Tz.html#variants">Show all compatible timezone</a>
```
"timezone": "Europe/Paris" 
````
</details>


<details open>
<summary><h3>3 - New feature: Add expire_at, delivery_at in stats [TEST PASSED] ✅</h3></summary>

Token statistics: it's now possible to retrieve delivery (creation) and expiration timestamps for each token.

exemple: 
```
  $ proxyauth stats
  [
    {
      "user": "admin",
      "tokens": [
        {
          "token_id": "Bhp^A63N0$wtT2L0eD6x7$r-fgVVOcN+2QtgHMWnFJfJWk-t",
          "count": 4,
          "delivery_at": "2025-05-28T12:58:19.695645278Z",
          "expire_at": "2025-06-02T12:58:03Z"
        }
      ]
    }
  ]
``` 
</details>

Prepare push on <a href="https://crates.proxyauth.app/crates">crates.proxyauth.app</a> stable latest version