### PR TITLE
database (multi instance Docker) to RAM sync every 15 seconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,7 +2095,7 @@ dependencies = [
 
 [[package]]
 name = "proxyauth"
-version = "0.8.2"
+version = "0.8.3-beta0"
 dependencies = [
  "actix-governor",
  "actix-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,20 +1649,21 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lmdb-rkv"
-version = "0.10.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8bff164607d2367d6bbdf54b5dd1a3c9412e68ae7d7c07fea7e7300bcc7780"
+checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
 dependencies = [
  "bitflags 1.3.2",
+ "byteorder",
  "libc",
- "lmdb-sys",
+ "lmdb-rkv-sys",
 ]
 
 [[package]]
-name = "lmdb-sys"
-version = "0.8.0"
+name = "lmdb-rkv-sys"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b392838cfe8858e86fac37cf97a0e8c55cc60ba0a18365cadc33092f128ce9"
+checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tracing",
 ]
@@ -201,7 +201,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2",
+ "socket2 0.5.9",
  "time",
  "tracing",
  "url",
@@ -684,6 +684,20 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1265,7 +1279,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1607,9 +1621,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"
@@ -1634,10 +1648,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
-name = "lmdb"
-version = "0.8.0"
+name = "lmdb-rkv"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0908efb5d6496aa977d96f91413da2635a902e5e31dbef0bfb88986c248539"
+checksum = "5c8bff164607d2367d6bbdf54b5dd1a3c9412e68ae7d7c07fea7e7300bcc7780"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -1814,10 +1828,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2126,13 +2159,14 @@ dependencies = [
  "ipnet",
  "itoa",
  "lazy_static",
- "lmdb",
+ "lmdb-rkv",
  "memchr",
  "nix",
  "once_cell",
  "quanta",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
+ "redis",
  "reqwest",
  "rustc-hash",
  "rustls",
@@ -2143,7 +2177,7 @@ dependencies = [
  "serde_urlencoded",
  "serde_yaml",
  "sha2",
- "socket2",
+ "socket2 0.5.9",
  "thiserror 2.0.12",
  "tokio",
  "totp-rs",
@@ -2251,6 +2285,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redis"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1f66bf4cac9733a23bcdf1e0e01effbaaad208567beba68be8f67e5f4af3ee1"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.6.0",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -2610,6 +2666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha1collisiondetection"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2751,16 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2916,7 +2988,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.9",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.8.3-beta0"
+version = "0.8.3"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proxyauth"
-version = "0.8.2"
+version = "0.8.3-beta0"
 edition = "2024"
 authors = ["Vladimir S"]
 repository = "https://github.com/ProxyAuth/ProxyAuth"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,4 @@ ahash = "0.8"
 lazy_static = "1.4"
 itoa = "1.0"
 redis = { version = "0.32", features = ["tokio-comp"] }
-lmdb-rkv = "0.10"
+lmdb-rkv = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,5 @@ serde_urlencoded = "0.7"
 ahash = "0.8"
 lazy_static = "1.4"
 itoa = "1.0"
-lmdb = "0.8"
+redis = { version = "0.32", features = ["tokio-comp"] }
+lmdb-rkv = "0.10"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ docker compose restart
 - Log to stdout using `tracing` (Rust log lib) [still being deployed]
 - ~Protect passwords config.json using Argon2.~ [Done v0.4.0]
 - ~Add Loki integration with tracing [needs further exploration]~ [Done >=0.5.2]
-- Add revoke token method.
+- ~Add revoke token method.~ Bonus: multi-cluster via redis [Done v0.8.3]
 
 # ProxyAuth Advantages
 - Centralized access point

--- a/src/adm/revoke.rs
+++ b/src/adm/revoke.rs
@@ -1,8 +1,8 @@
-use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use actix_web::{HttpRequest, HttpResponse, Responder, web};
 use serde::Deserialize;
 
 use crate::AppState;
-use crate::revoke::db::revoke_token;
+use crate::revoke::load::revoke_token;
 
 #[derive(Deserialize)]
 pub struct RevokeRequest {
@@ -23,7 +23,7 @@ pub async fn revoke_route(
             let token_id = &body.token_id;
             let exp = body.exp;
 
-            match revoke_token(token_id, exp, &data.revoked_tokens) {
+            match revoke_token(token_id, exp, &data.revoked_tokens).await {
                 Ok(_) => {
                     if exp.is_some() {
                         HttpResponse::Ok().body("Token revoked with expiration.")

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -16,5 +16,7 @@ pub enum Commands {
         insecure: bool,
     },
     Stats,
-    Sync { target: Option<String> },
+    Sync {
+        target: Option<String>,
+    },
 }

--- a/src/cli/prompt.rs
+++ b/src/cli/prompt.rs
@@ -2,7 +2,7 @@ use crate::cli::command::{Cli, Commands};
 use crate::config::config::{AppConfig, load_config};
 use crate::config::def_config::{
     ensure_running_as_proxyauth, ensure_running_as_root, ensure_user_proxyauth_exists,
-    setup_proxyauth_directory, setup_proxyauth_db_directory, switch_to_user,
+    setup_proxyauth_db_directory, setup_proxyauth_directory, switch_to_user,
 };
 use crate::keystore::export::export_as_file;
 use clap::Parser;

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,7 +1,7 @@
 use crate::adm::method_otp::generate_base32_secret;
+use crate::revoke::db::RevokedTokenMap;
 use crate::stats::tokencount::CounterToken;
 use crate::token::auth::generate_random_string;
-use crate::revoke::load::RevokedTokenMap;
 use argon2::password_hash::{SaltString, rand_core::OsRng};
 use argon2::{Argon2, PasswordHasher};
 use hyper::Client;
@@ -146,6 +146,9 @@ pub struct AppConfig {
 
     #[serde(default = "default_num_instances")]
     pub num_instances: u8,
+
+    #[serde(default)]
+    pub redis: Option<String>,
 }
 
 impl Serialize for AppConfig {

--- a/src/config/def_config.rs
+++ b/src/config/def_config.rs
@@ -165,8 +165,8 @@ pub fn setup_proxyauth_db_directory(insecure: bool) -> io::Result<()> {
     }
 
     let status_chown = Command::new("chown")
-    .args(["-R", "proxyauth:proxyauth", "/opt/proxyauth"])
-    .status()?;
+        .args(["-R", "proxyauth:proxyauth", "/opt/proxyauth"])
+        .status()?;
 
     if !status_chown.success() {
         eprintln!("Failed to change owner of /opt/proxyauth.");
@@ -176,8 +176,8 @@ pub fn setup_proxyauth_db_directory(insecure: bool) -> io::Result<()> {
     let chmod_mode = if insecure { "777" } else { "700" };
 
     let status_chmod = Command::new("chmod")
-    .args([chmod_mode, "/opt/proxyauth"])
-    .status()?;
+        .args([chmod_mode, "/opt/proxyauth"])
+        .status()?;
 
     if !status_chmod.success() {
         eprintln!("Failed to set permissions on /opt/proxyauth.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,10 @@ pub mod cli;
 pub mod config;
 pub mod keystore;
 pub mod network;
+pub mod revoke;
 pub mod stats;
 pub mod timezone;
 pub mod token;
-pub mod revoke;
 
 pub use config::config::{AppConfig, AppState, RouteConfig};
 pub use network::proxy::global_proxy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,6 @@ use socket2::{Domain, Protocol, Socket, Type};
 use start_actix::mode_actix_web;
 use stats::stats::stats as metric_stats;
 pub use stats::tokencount::CounterToken;
-use std::collections::HashMap;
 use std::net::TcpListener;
 use std::{fs, process, sync::Arc, time::Duration};
 use tls::load_rustls_config;
@@ -193,7 +192,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map(|v| v.trim_matches('"'))
             .unwrap_or("local");
 
-        let env_filter = EnvFilter::new("proxyauth=trace")
+        let env_filter = EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| EnvFilter::new("proxyauth=trace"))
             .add_directive("actix_web=warn".parse().unwrap())
             .add_directive("actix_server=warn".parse().unwrap());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,25 +19,26 @@ mod config;
 mod keystore;
 mod logs;
 mod network;
+mod revoke;
 mod start_actix;
 mod stats;
 mod timezone;
 mod tls;
 mod token;
-mod revoke;
 
 use crate::adm::registry_otp::get_otpauth_uri;
 use crate::adm::revoke::revoke_route;
 use crate::build::build_info::update_build_info;
 use crate::cli::prompt::prompt;
 use crate::keystore::import::decrypt_keystore;
-use crate::revoke::load::{start_revoked_token_ttl, load_revoked_tokens};
+use crate::revoke::db::{load_revoked_tokens, start_revoked_token_ttl};
 use crate::tls::check_port;
 use actix_governor::{Governor, GovernorConfigBuilder};
 use actix_web::{App, HttpServer, web};
 use chrono::Local;
 use config::config::{AppConfig, AppState, RouteConfig, load_config};
 use config::def_config::{create_config, ensure_running_as_proxyauth, switch_to_user};
+use dashmap::DashMap;
 use futures_util::future::join_all;
 use logs::{ChannelLogWriter, get_logs, log_collector};
 use network::proxy::global_proxy;
@@ -49,13 +50,14 @@ use socket2::{Domain, Protocol, Socket, Type};
 use start_actix::mode_actix_web;
 use stats::stats::stats as metric_stats;
 pub use stats::tokencount::CounterToken;
+use std::collections::HashMap;
 use std::net::TcpListener;
 use std::{fs, process, sync::Arc, time::Duration};
 use tls::load_rustls_config;
 use token::auth::auth;
 use token::security::init_derived_key;
 use tokio::sync::mpsc::unbounded_channel;
-use tracing::warn;
+use tracing::{error, warn};
 use tracing_loki::url::Url;
 use tracing_subscriber::Layer;
 use tracing_subscriber::filter::LevelFilter;
@@ -130,7 +132,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let counter_token = Arc::new(CounterToken::new());
 
-    let revoked_tokens = load_revoked_tokens().expect("failed to load revoked token database");
+    let revoked_tokens = match load_revoked_tokens() {
+        Ok(tokens) => tokens,
+        Err(e) => {
+            error!(
+                "Failed to load revoked token database: {}. Using empty token map.",
+                e
+            );
+            Arc::new(DashMap::new())
+        }
+    };
+
+    start_revoked_token_ttl(
+        revoked_tokens.clone(),
+        std::time::Duration::from_secs(15),
+        config.redis.clone(),
+    )
+    .await;
 
     let client_normal = build_hyper_client_normal(&config);
     let client_with_cert = build_hyper_client_cert(
@@ -162,10 +180,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         client_normal,
         client_with_cert,
         client_with_proxy,
-        revoked_tokens
+        revoked_tokens,
     });
 
-    start_revoked_token_ttl(state.revoked_tokens.clone(), Duration::from_secs(15)).await;
     init_derived_key(&config.secret);
 
     // logs

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         revoked_tokens
     });
 
-    start_revoked_token_ttl(state.revoked_tokens.clone(), Duration::from_secs(60)).await;
+    start_revoked_token_ttl(state.revoked_tokens.clone(), Duration::from_secs(15)).await;
     init_derived_key(&config.secret);
 
     // logs

--- a/src/revoke/db.rs
+++ b/src/revoke/db.rs
@@ -1,55 +1,211 @@
-use lmdb::{Environment, WriteFlags, Transaction};
+use anyhow::Error;
+use dashmap::DashMap;
+use lmdb::{Cursor, Environment, Transaction};
 use std::path::Path;
-use crate::revoke::load::RevokedTokenMap;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
+use std::sync::Arc;
+use std::thread::{self, sleep};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use lmdb::WriteFlags;
+use once_cell::sync::OnceCell;
+use redis::{Client, Commands};
 
-pub fn is_token_revoked(token_id: &str, revoked_tokens: &RevokedTokenMap) -> bool {
-    let now = SystemTime::now()
-    .duration_since(UNIX_EPOCH)
-    .unwrap()
-    .as_secs();
+pub static REDIS: OnceCell<Client> = OnceCell::new();
+pub static LMDB_ENV: OnceCell<lmdb::Environment> = OnceCell::new();
 
-    let map = revoked_tokens.read().unwrap();
+pub type RevokedTokenMap = Arc<DashMap<String, u64>>;
 
-    match map.get(token_id) {
-        Some(&0) => true,
-        Some(&exp) if now >= exp => true,
-        _ => false,
+
+pub async fn start_revoked_token_ttl(
+    revoked_tokens: RevokedTokenMap,
+    every: Duration,
+    redis_url: Option<String>,
+) {
+    let opt_path = Some("/opt/proxyauth/db/".to_string());
+
+    // Init LMDB
+    if let Some(path) = opt_path {
+        if LMDB_ENV.get().is_none() {
+            let env = Environment::new()
+            .set_max_dbs(1)
+            .open(Path::new(&path))
+            .expect("Failed to open LMDB");
+            LMDB_ENV.set(env).expect("LMDB already initialized");
+        }
+    }
+
+    // Init Redis
+    if let Some(url) = redis_url {
+        if REDIS.get().is_none() {
+            let client = Client::open(url).expect("Invalid Redis URL");
+            REDIS.set(client).expect("REDIS client already initialized");
+        }
+
+        thread::spawn(move || {
+            loop {
+                // Redis -> LMDB + RAM
+                if let Some(client) = REDIS.get() {
+                    if let Ok(mut con) = client.get_connection() {
+                        let action_keys: Vec<String> = match con.scan_match::<String, String>("*_action".to_string()) {
+                            Ok(iter) => iter.collect::<Vec<String>>(),
+                      Err(_) => Vec::new(),
+                        };
+
+                        for action_key in action_keys {
+                            let token_id = action_key.trim_end_matches("_action");
+                            //println!("[RevokedSync] Processing token_id: {}", token_id);
+
+                            let action: Result<String, _> = con.get(&action_key);
+
+                            match action.as_deref() {
+                                Ok("1") => {
+                                    let exp_result = con.get::<_, u64>(&format!("token:{}", token_id));
+                                    let key: &[u8] = token_id.as_bytes();
+                                    let value_buf;
+                                    let value: &[u8] = match exp_result {
+                                        Ok(exp) => {
+                                            value_buf = exp.to_be_bytes();
+                                            &value_buf
+                                        }
+                                        Err(_) => &[],
+                                    };
+
+                                    let mut should_update = true;
+
+                                    if let Some(env) = LMDB_ENV.get() {
+                                        if let Ok(db) = env.open_db(Some("revoke")) {
+                                            if let Ok(txn) = env.begin_ro_txn() {
+                                                if let Ok(existing) = txn.get::<&[u8]>(db, &key) {
+                                                    should_update = existing != value;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    if should_update {
+                                        if let Some(env) = LMDB_ENV.get() {
+                                            if let Ok(db) = env.open_db(Some("revoke")) {
+                                                if let Ok(mut txn) = env.begin_rw_txn() {
+                                                    if let Err(e) = txn.put::<&[u8], &[u8]>(db, &key, &value, WriteFlags::empty()) {
+                                                        eprintln!("[RevokedSync] LMDB put error for {}: {}", token_id, e);
+                                                    }
+                                                    let _ = txn.commit();
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    let exp_val = match value.len() {
+                                        8 => Some(u64::from_be_bytes(value.try_into().unwrap())),
+                                        0 => Some(0),
+                                        _ => None,
+                                    };
+
+                                    if let Some(exp) = exp_val {
+                                        revoked_tokens.insert(token_id.to_string(), exp);
+                                    }
+                                }
+                                Ok("2") => {
+                                    if let Some(env) = LMDB_ENV.get() {
+                                        if let Ok(db) = env.open_db(Some("revoke")) {
+                                            if let Ok(mut txn) = env.begin_rw_txn() {
+                                                let key = token_id.as_bytes();
+                                                let _ = txn.del::<&[u8]>(db, &key, None)
+                                                .map_err(|e| eprintln!("[RevokedSync] LMDB delete error for {}: {}", token_id, e));
+                                                let _ = txn.commit();
+                                            }
+                                        }
+                                    }
+                                    revoked_tokens.remove(token_id);
+                                }
+                                other => {
+                                    //println!("[RevokedSync] Unknown or missing action for {}: {:?}", token_id, other);
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // LMDB -> RAM
+                if let Some(env) = LMDB_ENV.get() {
+                    if let Ok(db) = env.open_db(Some("revoke")) {
+                        if let Ok(txn) = env.begin_ro_txn() {
+                            if let Ok(mut cursor) = txn.open_ro_cursor(db) {
+                                for (key, value) in cursor.iter() {
+                                    let token_id = match std::str::from_utf8(key) {
+                                        Ok(s) => s.to_string(),
+                                        Err(_) => continue,
+                                    };
+
+                                    let exp = if value.len() == 8 {
+                                        match value.try_into().map(u64::from_be_bytes) {
+                                            Ok(e) => e,
+                                            Err(_) => continue,
+                                        }
+                                    } else if value.is_empty() {
+                                        0
+                                    } else {
+                                        continue
+                                    };
+
+                                    revoked_tokens.insert(token_id, exp);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // RAM purge
+                let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+                let before = revoked_tokens.len();
+                revoked_tokens.retain(|_, &mut exp| exp == 0 || exp > now);
+                let after = revoked_tokens.len();
+
+                if before != after {
+                    println!("[RevokedSync] Purged {} expired tokens", before - after);
+                }
+
+                sleep(every);
+            }
+        });
     }
 }
 
-pub fn revoke_token(
-    token_id: &str,
-    token_exp: Option<u64>,
-    revoked_tokens: &RevokedTokenMap,
-) -> anyhow::Result<()> {
-    let env = Environment::new()
-    .set_max_dbs(1)
-    .open(Path::new("/opt/proxyauth/db"))?;
 
-    let db = env.open_db(Some("revoke"))?;
-    let mut txn = env.begin_rw_txn()?;
+pub fn load_revoked_tokens() -> Result<Arc<DashMap<String, u64>>, Error> {
+    let map = DashMap::new();
 
-    let value = if let Some(exp) = token_exp {
-        exp.to_be_bytes().to_vec()
-    } else {
-        Vec::new()
-    };
+    if let Some(env) = LMDB_ENV.get() {
+        let db = env.open_db(Some("revoke"))?;
+        let txn = env.begin_ro_txn()?;
+        let mut cursor = txn.open_ro_cursor(db)?;
 
-    txn.put(db, &token_id, &value, WriteFlags::empty())?;
-    txn.commit()?;
+        for (key, value) in cursor.iter() {
+            let token_id = match std::str::from_utf8(key) {
+                Ok(s) => s.to_string(),
+                Err(_) => continue,
+            };
 
-    let mut map = revoked_tokens.write().unwrap();
-    match token_exp {
-        Some(exp) => {
-            map.insert(token_id.to_string(), exp);
+            let exp = if value.len() == 8 {
+                match value.try_into().map(u64::from_be_bytes) {
+                    Ok(exp) => exp,
+                    Err(_) => continue,
+                }
+            } else if value.is_empty() {
+                0
+            } else {
+                continue;
+            };
+
+            map.insert(token_id, exp);
         }
-        None => {
-            map.insert(token_id.to_string(), 0);
-        }
+
+        return Ok(Arc::new(map));
     }
 
-    Ok(())
+    Err(anyhow::anyhow!("LMDB is not initialized"))
 }
 

--- a/src/revoke/db.rs
+++ b/src/revoke/db.rs
@@ -8,12 +8,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use lmdb::WriteFlags;
 use once_cell::sync::OnceCell;
 use redis::{Client, Commands};
+use tracing::{debug, error};
 
 pub static REDIS: OnceCell<Client> = OnceCell::new();
 pub static LMDB_ENV: OnceCell<lmdb::Environment> = OnceCell::new();
 
 pub type RevokedTokenMap = Arc<DashMap<String, u64>>;
-
 
 pub async fn start_revoked_token_ttl(
     revoked_tokens: RevokedTokenMap,
@@ -43,11 +43,14 @@ pub async fn start_revoked_token_ttl(
         thread::spawn(move || {
             loop {
                 // Redis -> LMDB + RAM
+
+                debug!("[RevokedSync] Fetched tokens from Redis");
+
                 if let Some(client) = REDIS.get() {
                     if let Ok(mut con) = client.get_connection() {
                         let action_keys: Vec<String> = match con.scan_match::<String, String>("*_action".to_string()) {
                             Ok(iter) => iter.collect::<Vec<String>>(),
-                      Err(_) => Vec::new(),
+                            Err(_) => Vec::new(),
                         };
 
                         for action_key in action_keys {
@@ -86,7 +89,7 @@ pub async fn start_revoked_token_ttl(
                                             if let Ok(db) = env.open_db(Some("revoke")) {
                                                 if let Ok(mut txn) = env.begin_rw_txn() {
                                                     if let Err(e) = txn.put::<&[u8], &[u8]>(db, &key, &value, WriteFlags::empty()) {
-                                                        eprintln!("[RevokedSync] LMDB put error for {}: {}", token_id, e);
+                                                        error!("[RevokedSync] LMDB put error for {}: {}", token_id, e);
                                                     }
                                                     let _ = txn.commit();
                                                 }
@@ -110,15 +113,15 @@ pub async fn start_revoked_token_ttl(
                                             if let Ok(mut txn) = env.begin_rw_txn() {
                                                 let key = token_id.as_bytes();
                                                 let _ = txn.del::<&[u8]>(db, &key, None)
-                                                .map_err(|e| eprintln!("[RevokedSync] LMDB delete error for {}: {}", token_id, e));
+                                                .map_err(|e| error!("[RevokedSync] LMDB delete error for {}: {}", token_id, e));
                                                 let _ = txn.commit();
                                             }
                                         }
                                     }
                                     revoked_tokens.remove(token_id);
                                 }
-                                other => {
-                                    //println!("[RevokedSync] Unknown or missing action for {}: {:?}", token_id, other);
+                                _other => {
+                                    //debug!("[RevokedSync] Unknown or missing action for {}: {:?}", token_id, other);
                                     continue;
                                 }
                             }
@@ -131,7 +134,12 @@ pub async fn start_revoked_token_ttl(
                     if let Ok(db) = env.open_db(Some("revoke")) {
                         if let Ok(txn) = env.begin_ro_txn() {
                             if let Ok(mut cursor) = txn.open_ro_cursor(db) {
-                                for (key, value) in cursor.iter() {
+                                for result in cursor.iter() {
+                                    let (key, value) = match result {
+                                        Ok((key, value)) => (key, value),
+                                        Err(_) => continue,
+                                    };
+
                                     let token_id = match std::str::from_utf8(key) {
                                         Ok(s) => s.to_string(),
                                         Err(_) => continue,
@@ -145,7 +153,7 @@ pub async fn start_revoked_token_ttl(
                                     } else if value.is_empty() {
                                         0
                                     } else {
-                                        continue
+                                        continue;
                                     };
 
                                     revoked_tokens.insert(token_id, exp);
@@ -165,7 +173,7 @@ pub async fn start_revoked_token_ttl(
                 let after = revoked_tokens.len();
 
                 if before != after {
-                    println!("[RevokedSync] Purged {} expired tokens", before - after);
+                    debug!("[RevokedSync] Purged {} expired tokens", before - after);
                 }
 
                 sleep(every);
@@ -183,7 +191,15 @@ pub fn load_revoked_tokens() -> Result<Arc<DashMap<String, u64>>, Error> {
         let txn = env.begin_ro_txn()?;
         let mut cursor = txn.open_ro_cursor(db)?;
 
-        for (key, value) in cursor.iter() {
+        for result in cursor.iter() {
+            let (key, value) = match result {
+                Ok((key, value)) => (key, value),
+                Err(e) => {
+                    error!("Error while iterating LMDB: {}", e);
+                    continue;
+                }
+            };
+
             let token_id = match std::str::from_utf8(key) {
                 Ok(s) => s.to_string(),
                 Err(_) => continue,

--- a/src/revoke/load.rs
+++ b/src/revoke/load.rs
@@ -14,36 +14,67 @@ pub async fn start_revoked_token_ttl(
     revoked_tokens: RevokedTokenMap,
     every: Duration,
 ) {
+    let env = Environment::new()
+    .set_max_dbs(1)
+    .set_map_size(1048576000)
+    .open(Path::new("/opt/proxyauth/db"))
+    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", db_path, e))
+    .expect("Failed to open LMDB environment");
+
+    let db = env
+    .create_db(Some("revoke"), DatabaseFlags::empty())
+    .map_err(|e| anyhow::anyhow!("Failed to create LMDB database: {}", e))
+    .expect("Failed to create LMDB database");
+
     tokio::spawn(async move {
         loop {
-            tokio::time::sleep(every).await;
+            match load_revoked_tokens_from_db(&env, db) {
+                Ok((new_map, db_count)) => {
+                    let mut map = revoked_tokens.write().unwrap();
+                    let ram_count = map.len();
 
-            let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+                    if ram_count != db_count {
+                        let before = ram_count;
+                        *map = new_map;
+                        let after = map.len();
+                        println!(
+                            "[RevokedCleaner] Synchronized token map",
+                        );
+                    } else {
+                        println!("[RevokedCleaner] No synchronization needed",);
+                    }
 
-            let mut map = revoked_tokens.write().unwrap();
-            let before = map.len();
-            map.retain(|_, &mut exp| exp > now);
-            let after = map.len();
+                    // Nettoyer les jetons expirés
+                    let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                    let before = map.len();
+                    map.retain(|_, &mut exp| exp > now);
+                    let after = map.len();
 
-            if before != after {
-                println!("[RevokedCleaner] Purged {} expired tokens", before - after);
+                    if before != after {
+                        println!("[RevokedCleaner] Purged {} expired tokens", before - after);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("[RevokedCleaner] Failed to load tokens from database: {}", e);
+                }
             }
+
+            tokio::time::sleep(every).await;
         }
     });
 }
 
-pub fn load_revoked_tokens() -> Result<RevokedTokenMap, anyhow::Error> {
-    let env = Environment::new()
-    .set_max_dbs(1)
-    .open(Path::new("/opt/proxyauth/db"))?;
-
-    let db = env.create_db(Some("revoke"), DatabaseFlags::empty())?;
+fn load_revoked_tokens_from_db(
+    env: &Environment,
+    db: lmdb::Database,
+) -> Result<(HashMap<String, u64>, usize), anyhow::Error> {
     let txn = env.begin_ro_txn()?;
     let mut map = HashMap::new();
     let mut cursor = txn.open_ro_cursor(db)?;
+    let mut count = 0;
 
     for (key, value) in cursor.iter() {
         let token_id = match std::str::from_utf8(key) {
@@ -63,7 +94,28 @@ pub fn load_revoked_tokens() -> Result<RevokedTokenMap, anyhow::Error> {
         };
 
         map.insert(token_id, exp);
+        count += 1;
     }
 
+    Ok((map, count))
+}
+
+pub fn load_revoked_tokens() -> Result<RevokedTokenMap, anyhow::Error> {
+    if !Path::new(db_path).exists() {
+        std::fs::create_dir_all("/opt/proxyauth/db")
+        .map_err(|e| anyhow::anyhow!("Failed to create directory {}: {}", db_path, e))?;
+    }
+
+    let env = Environment::new()
+    .set_max_dbs(1)
+    .set_map_size(1048576000)
+    .open(Path::new(db_path))
+    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", db_path, e))?;
+
+    let db = env
+    .create_db(Some("revoke"), DatabaseFlags::empty())
+    .map_err(|e| anyhow::anyhow!("Failed to create LMDB database: {}", e))?;
+
+    let (map, _) = load_revoked_tokens_from_db(&env, db)?;
     Ok(Arc::new(RwLock::new(map)))
 }

--- a/src/revoke/load.rs
+++ b/src/revoke/load.rs
@@ -18,7 +18,7 @@ pub async fn start_revoked_token_ttl(
     .set_max_dbs(1)
     .set_map_size(1048576000)
     .open(Path::new("/opt/proxyauth/db"))
-    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", db_path, e))
+    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", "/opt/proxyauth/db", e))
     .expect("Failed to open LMDB environment");
 
     let db = env
@@ -34,17 +34,15 @@ pub async fn start_revoked_token_ttl(
                     let ram_count = map.len();
 
                     if ram_count != db_count {
-                        let before = ram_count;
+                        let _before = ram_count;
                         *map = new_map;
-                        let after = map.len();
+                        let _after = map.len();
                         println!(
                             "[RevokedCleaner] Synchronized token map",
                         );
-                    } else {
-                        println!("[RevokedCleaner] No synchronization needed",);
                     }
 
-                    // Nettoyer les jetons expirés
+                    // clear tokens expires
                     let now = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap()
@@ -101,16 +99,16 @@ fn load_revoked_tokens_from_db(
 }
 
 pub fn load_revoked_tokens() -> Result<RevokedTokenMap, anyhow::Error> {
-    if !Path::new(db_path).exists() {
+    if !Path::new("/opt/proxyauth/db").exists() {
         std::fs::create_dir_all("/opt/proxyauth/db")
-        .map_err(|e| anyhow::anyhow!("Failed to create directory {}: {}", db_path, e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to create directory {}: {}", "/opt/proxyauth/db", e))?;
     }
 
     let env = Environment::new()
     .set_max_dbs(1)
     .set_map_size(1048576000)
-    .open(Path::new(db_path))
-    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", db_path, e))?;
+    .open(Path::new("/opt/proxyauth/db"))
+    .map_err(|e| anyhow::anyhow!("Failed to open LMDB environment at {}: {}", "/opt/proxyauth/db", e))?;
 
     let db = env
     .create_db(Some("revoke"), DatabaseFlags::empty())

--- a/src/revoke/mod.rs
+++ b/src/revoke/mod.rs
@@ -12,5 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod load;
 pub mod db;
+pub mod load;

--- a/src/token/security.rs
+++ b/src/token/security.rs
@@ -1,7 +1,7 @@
 use crate::AppConfig;
 use crate::AppState;
 use crate::build::build_info::get;
-use crate::revoke::db::is_token_revoked;
+use crate::revoke::load::is_token_revoked;
 use crate::timezone::check_date_token;
 use crate::token::crypto::{calcul_factorhash, decrypt, derive_key_from_secret};
 use actix_web::web;
@@ -187,7 +187,6 @@ pub async fn validate_token(
         return Err("Bad time token".to_string());
     }
 
-
     let token_generated = generate_token(&user.username, &config, data[1], data[3]);
     let token_hash = calcul_factorhash(token_generated);
 
@@ -197,7 +196,10 @@ pub async fn validate_token(
     }
 
     if is_token_revoked(data[3], &data_app.revoked_tokens) {
-        warn!("[{}] token_id {} is revoked from user {}", ip, data[3], user.username);
+        warn!(
+            "[{}] token_id {} is revoked from user {}",
+            ip, data[3], user.username
+        );
         return Err("revoked token".to_string());
     }
 


### PR DESCRIPTION
Running tests with multiple ProxyAuth instances sharing a synchronized database via Docker volumes.
use docker container demo: https://github.com/ProxyAuth/Docker
- Switched to Redis for improved concurrent read/write access.

use redis in config.json

```
"redis": "redis://redis_server:6379"
```


Added Redis support to enable shared token revocation across multiple instances.
Redis is optional and not required to run ProxyAuth.

LMDB test
<img width="3367" height="620" alt="image" src="https://github.com/user-attachments/assets/d5de8d62-aebc-4509-bfc8-6dad47c9909b" />

Redis test: both clusters are successfully synchronized via Redis. Each server waits up to 15 seconds for sync, but it works perfectly!
<img width="2002" height="296" alt="image" src="https://github.com/user-attachments/assets/2f895883-182d-4285-8d25-624858d7a8d8" />


it's my logic
<img width="1280" height="1706" alt="image" src="https://github.com/user-attachments/assets/0d16de04-51b3-4a63-a889-2854b93727e8" />


